### PR TITLE
feat(multi-agent): session templates, agents layer, spec lifecycle commands, orchestrator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,9 @@ TASK_PROGRESS.md
 CONTEXT_SUMMARY.md
 VALIDATION_STATE.md
 .parallel_*.txt
+
+# Exception: session template files in the package must be versioned
+!claudex/templates/project/session/CURRENT_TASK.md
+!claudex/templates/project/session/TASK_PROGRESS.md
+!claudex/templates/project/session/CONTEXT_SUMMARY.md
+!claudex/templates/project/session/VALIDATION_STATE.md

--- a/claudex/templates/project/agents/implementers.yml
+++ b/claudex/templates/project/agents/implementers.yml
@@ -1,0 +1,131 @@
+# ClaudeX Implementer Role Registry
+# Used by claudex init --multi-agent to generate agent files in .claude/agents/
+
+version: "1.0"
+
+roles:
+  - id: api-engineer
+    name: API Engineer
+    description: FastAPI/REST endpoints, request validation, response schemas, middleware
+    focus:
+      - REST and GraphQL endpoint design
+      - Request/response validation with Pydantic
+      - Authentication and authorization middleware
+      - API versioning and backward compatibility
+    files_owned:
+      - "src/api/**"
+      - "src/routers/**"
+    must_not_touch:
+      - "src/core/**"
+      - "src/db/**"
+
+  - id: database-engineer
+    name: Database Engineer
+    description: SQLAlchemy ORM models, Alembic migrations, repository implementations, query optimization
+    focus:
+      - Database schema design and normalization
+      - ORM model definitions and relationships
+      - Alembic migration scripts
+      - Repository pattern implementation
+      - Query optimization and indexing
+    files_owned:
+      - "src/db/**"
+      - "alembic/**"
+    must_not_touch:
+      - "src/api/**"
+      - "src/core/**"
+
+  - id: ui-designer
+    name: UI Designer
+    description: React/Next.js components, Tailwind styling, responsive layouts, accessibility
+    focus:
+      - Component architecture and composition
+      - Responsive design and mobile-first layouts
+      - Accessibility (WCAG 2.1 AA)
+      - State management (React hooks, Zustand)
+      - Design system and Tailwind utility classes
+    files_owned:
+      - "src/components/**"
+      - "src/pages/**"
+      - "src/styles/**"
+    must_not_touch:
+      - "src/api/**"
+      - "src/db/**"
+
+  - id: testing-engineer
+    name: Testing Engineer
+    description: Unit tests, integration tests, E2E tests, test fixtures, coverage reporting
+    focus:
+      - TDD workflow (red → green → refactor)
+      - pytest unit and integration tests
+      - Test fixture design and factories
+      - Mock strategies for external dependencies
+      - Coverage analysis and gap identification
+    files_owned:
+      - "tests/**"
+    must_not_touch: []
+
+  - id: devops-engineer
+    name: DevOps Engineer
+    description: CI/CD pipelines, Docker, Kubernetes, deployment automation, monitoring
+    focus:
+      - GitHub Actions workflow design
+      - Docker and docker-compose configuration
+      - Cloud infrastructure (AWS/GCP/Azure)
+      - Monitoring and alerting setup
+      - Secret management and environment configuration
+    files_owned:
+      - ".github/workflows/**"
+      - "docker/**"
+      - "k8s/**"
+      - "infra/**"
+    must_not_touch:
+      - "src/**"
+      - "tests/**"
+
+  - id: security-engineer
+    name: Security Engineer
+    description: Authentication, authorization, OWASP hardening, secret scanning, audit logging
+    focus:
+      - Authentication flows (JWT, OAuth2, API keys)
+      - Authorization and RBAC implementation
+      - OWASP Top 10 vulnerability remediation
+      - Input validation and sanitization
+      - Audit logging and compliance
+    files_owned:
+      - "src/auth/**"
+      - "src/security/**"
+    must_not_touch: []
+
+  - id: data-engineer
+    name: Data Engineer
+    description: ETL pipelines, data processing workers, analytics schemas, data quality
+    focus:
+      - ETL/ELT pipeline design
+      - Background data processing tasks
+      - Analytics and reporting schemas
+      - Data quality validation
+      - Stream processing integration
+    files_owned:
+      - "src/workers/**"
+      - "src/pipelines/**"
+      - "src/analytics/**"
+    must_not_touch:
+      - "src/api/**"
+      - "src/core/**"
+
+  - id: docs-engineer
+    name: Documentation Engineer
+    description: API docs, README, architecture docs, ADRs, user guides, code comments
+    focus:
+      - OpenAPI/Swagger documentation
+      - README and getting-started guides
+      - Architecture Decision Records (ADRs)
+      - Code documentation and docstrings
+      - Changelog and release notes
+    files_owned:
+      - "docs/**"
+      - "*.md"
+    must_not_touch:
+      - "src/**"
+      - "tests/**"

--- a/claudex/templates/project/agents/orchestrator.md
+++ b/claudex/templates/project/agents/orchestrator.md
@@ -1,0 +1,76 @@
+# Orchestrator Agent
+
+You are the **ClaudeX Orchestrator** — a meta-routing agent that receives any development task
+and routes it to the correct specialist agent without the user having to choose.
+
+## Your Role
+
+You do NOT implement. You plan, assign, and coordinate.
+
+When given a task:
+1. Classify the task type using the taxonomy below
+2. Select the correct specialist agent(s)
+3. Generate a context handoff document for each agent
+4. Return the routing plan to the user
+
+## Task Taxonomy
+
+| Type | Sub-type | Assign to |
+|------|----------|-----------|
+| build | api endpoint | api-engineer |
+| build | database schema | database-engineer |
+| build | UI component | ui-designer |
+| build | background job | api-engineer |
+| build | infrastructure | devops-engineer |
+| build | data pipeline | data-engineer |
+| build | security feature | security-engineer |
+| build | documentation | docs-engineer |
+| fix | any bug | matching specialist |
+| refactor | any | matching specialist |
+| test | unit/integration | testing-engineer |
+| test | E2E | testing-engineer |
+| research | technical | any relevant specialist |
+| ops | deploy/CI | devops-engineer |
+| docs | any | docs-engineer |
+
+## Routing Decision Process
+
+```
+1. Read the task description carefully
+2. Identify the PRIMARY concern (what is the main deliverable?)
+3. Select the primary agent from the taxonomy
+4. Identify any secondary concerns (e.g., "build API + add tests")
+5. List all agents needed in execution order
+6. Generate context-handoff.md for each agent
+7. Return the routing plan
+```
+
+## Output Format
+
+When routing a task, output:
+
+```markdown
+## Routing Plan: [task title]
+
+**Primary agent**: [agent-name]
+**Secondary agents**: [agent-name, ...] (or none)
+**Execution order**: [1. agent-name → 2. agent-name → ...]
+
+### Context Handoff: Orchestrator → [primary-agent]
+**Task**: [specific instructions for this agent]
+**Context**: [relevant background the agent needs]
+**Completed**: [nothing yet — this is the first agent]
+**Files to touch**: [expected file paths]
+**Done when**: [specific acceptance criteria]
+**Gotchas**: [known constraints or pitfalls]
+
+### Context Handoff: [primary-agent] → [secondary-agent]
+[Same structure, populated after primary agent completes]
+```
+
+## Constraints
+
+- Never start implementation yourself
+- If the task is unclear, ask ONE clarifying question before routing
+- If a task spans 3+ agents, suggest splitting into separate issues
+- Always generate the context handoff document — never hand off raw task descriptions

--- a/claudex/templates/project/agents/verifiers.yml
+++ b/claudex/templates/project/agents/verifiers.yml
@@ -1,0 +1,66 @@
+# ClaudeX Verifier Role Registry
+# Verifiers run AFTER implementers to validate correctness, quality, and security.
+
+version: "1.0"
+
+roles:
+  - id: architecture-verifier
+    name: Architecture Verifier
+    description: Checks layer boundaries, dependency direction, circular imports, SRP violations
+    runs_after:
+      - any implementer
+    checks:
+      - Layer violations (core importing from api, db importing from workers, etc.)
+      - Circular dependency detection
+      - Single Responsibility Principle adherence
+      - Interface segregation compliance
+    output: "verification/architecture-report.md"
+    blocks_merge_on: critical
+
+  - id: security-verifier
+    name: Security Verifier
+    description: OWASP Top 10 scan, hardcoded secrets detection, input validation gaps
+    runs_after:
+      - api-engineer
+      - security-engineer
+      - database-engineer
+    checks:
+      - SQL injection (parameterized queries check)
+      - XSS vulnerabilities in any rendered output
+      - Hardcoded secrets or credentials
+      - Missing input validation at API boundaries
+      - Authentication bypass risks
+      - Insecure direct object references
+    output: "verification/security-report.md"
+    blocks_merge_on: any
+
+  - id: quality-verifier
+    name: Quality Verifier
+    description: File size limits, method complexity, naming conventions, lint compliance
+    runs_after:
+      - any implementer
+    checks:
+      - File size ≤500 lines (≤300 preferred)
+      - Method length ≤50 lines (≤30 preferred)
+      - Naming convention compliance (see NAMING_CONVENTIONS.md)
+      - Ruff lint and format passing
+      - No bare except clauses
+      - No dead code (unreachable branches)
+    output: "verification/quality-report.md"
+    blocks_merge_on: critical
+
+  - id: test-verifier
+    name: Test Verifier
+    description: Coverage analysis, test quality, missing edge cases, flaky test detection
+    runs_after:
+      - testing-engineer
+      - any implementer
+    checks:
+      - Core layer coverage ≥95%
+      - API layer coverage ≥80%
+      - All tests passing (zero failures, zero errors)
+      - AAA pattern compliance in test structure
+      - Edge cases covered (None, empty, boundary values)
+      - No skipped tests without justification
+    output: "verification/test-report.md"
+    blocks_merge_on: any

--- a/claudex/templates/project/commands/context-handoff.md
+++ b/claudex/templates/project/commands/context-handoff.md
@@ -1,0 +1,74 @@
+# /context-handoff — Structured Agent-to-Agent Context Transfer
+
+Generate a structured context handoff document when transitioning work
+between agents. Prevents context loss and ensures agents have everything
+they need to continue without asking redundant questions.
+
+## Usage
+```
+/context-handoff <source-agent> <target-agent> <task-description>
+```
+Example: `/context-handoff orchestrator api-engineer "implement POST /auth/login endpoint"`
+
+## Handoff Document Format
+
+Generate `verification/handoff-<target-agent>.md`:
+
+```markdown
+# Context Handoff: <source> → <target>
+_Generated: <date>_
+
+## Task
+<Specific, actionable task description — not the full spec>
+
+## Completed Work
+<What has already been done — be precise about file paths and decisions>
+- None (first agent in chain)
+  OR
+- <file.py>: <what was done>
+
+## Your Pending Work
+<Explicit list of what THIS agent needs to do>
+1. <action 1>
+2. <action 2>
+
+## Decision Log
+<Architectural and approach decisions already made — the target agent must honor these>
+- <decision 1>: <brief rationale>
+
+## Files to Touch
+<Expected file paths this agent will read or write>
+- CREATE: <path> — <purpose>
+- MODIFY: <path> — <what changes>
+- READ: <path> — <why>
+
+## Files NOT to Touch
+<Files owned by other agents or that must not change>
+- <path> — <owned by: role>
+
+## Gotchas
+<Known pitfalls, constraints, or non-obvious requirements>
+- <gotcha 1>
+
+## Done Condition
+<How the target agent knows it's finished>
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+## Hand Back To
+<Next agent in chain, or "orchestrator" if this is the last agent>
+```
+
+## When to Use This
+
+- Before any agent-to-agent task transfer in `/implement-spec`
+- When switching from one specialist to another mid-feature
+- When resuming work after a session break (handoff from "previous session" → "current agent")
+- When splitting a task between parallel background agents
+
+## What Makes a Good Handoff
+
+1. **Specific files** — list exact paths, not vague descriptions
+2. **Decision log** — what was decided AND why, so the next agent doesn't re-litigate
+3. **Explicit boundaries** — what NOT to touch is as important as what to touch
+4. **Testable done condition** — the agent can self-verify completion

--- a/claudex/templates/project/commands/create-spec.md
+++ b/claudex/templates/project/commands/create-spec.md
@@ -1,0 +1,10 @@
+# /create-spec — Alias for /new-spec
+
+Create a new feature specification. This is an alias for `/new-spec`.
+
+## Usage
+```
+/create-spec <feature-title>
+```
+
+See `/new-spec` for the full process.

--- a/claudex/templates/project/commands/implement-spec.md
+++ b/claudex/templates/project/commands/implement-spec.md
@@ -1,0 +1,94 @@
+# /implement-spec — 5-Phase Spec Implementation
+
+Implements a spec through a structured multi-agent workflow.
+
+## Usage
+```
+/implement-spec <spec-file-path>
+```
+Example: `/implement-spec docs/specs/user-auth.md`
+
+## Phase 1: Plan Subagent Assignments
+
+Read the spec file. Identify all implementation concerns. For each concern:
+- Select the appropriate implementer role from `agents/implementers.yml`
+- Estimate scope (files to touch, rough complexity)
+- Identify dependencies between agents (execution order)
+
+Output `verification/task-assignments.yml`:
+
+```yaml
+spec: <spec-path>
+created: <date>
+
+assignments:
+  - id: "assign-1"
+    role: api-engineer
+    task: "<specific task description>"
+    files: ["src/api/routes/auth.py", "src/api/schemas/auth.py"]
+    depends_on: ["assign-2"]
+
+  - id: "assign-2"
+    role: database-engineer
+    task: "<specific task description>"
+    files: ["src/db/models/user.py", "alembic/versions/xxx_add_users.py"]
+    depends_on: []
+```
+
+## Phase 2: Context Handoff
+
+For each agent in execution order, generate a context handoff document
+using `/context-handoff`. This ensures agents receive structured context,
+not raw task descriptions.
+
+Each handoff is saved to `verification/handoff-<role>.md`.
+
+## Phase 3: Delegate to Implementers
+
+In execution order (respecting `depends_on`):
+
+1. Present the handoff document to the appropriate specialist command
+   (e.g., `/expert-backend`, `/expert-devops`)
+2. The implementer works and returns results
+3. Record completion status in `task-assignments.yml`
+
+For parallel-safe assignments (no shared files, no dependencies), these
+can be run as background agents — see `agents/` directory.
+
+## Phase 4: Delegate to Verifiers
+
+After all implementers complete, run each applicable verifier
+from `agents/verifiers.yml`:
+
+- Always run: architecture-verifier, quality-verifier, test-verifier
+- Run if security changes: security-verifier
+
+Each verifier writes its report to `verification/<type>-report.md`.
+
+## Phase 5: Final Verification
+
+Review all verifier reports. Check:
+- [ ] Zero critical issues across all reports
+- [ ] All acceptance criteria from the spec are met
+- [ ] All tests pass
+- [ ] Lint and format clean
+
+If issues found: route back to the relevant implementer (Phase 3).
+If clean: write `verification/final-verification.md` and close the GitHub issue.
+
+```markdown
+# Final Verification: <spec title>
+_Completed: <date>_
+
+## Acceptance Criteria
+- [x] <criterion 1>
+- [x] <criterion 2>
+
+## Verifier Reports
+- Architecture: ✅ clean
+- Quality: ✅ clean
+- Security: ✅ clean
+- Tests: ✅ 95% coverage
+
+## Ready to merge: YES
+```

--- a/claudex/templates/project/commands/new-spec.md
+++ b/claudex/templates/project/commands/new-spec.md
@@ -1,0 +1,74 @@
+# /new-spec — Interactive Spec Creator
+
+Create a new feature specification through guided questions.
+
+## Usage
+```
+/new-spec <feature-title>
+```
+
+## Process
+
+### Step 1: Gather Requirements
+Ask the user these questions (wait for answers before proceeding):
+
+1. **Goal**: What problem does this feature solve? Who benefits?
+2. **Scope**: What is explicitly OUT of scope for this spec?
+3. **Inputs**: What data or events trigger this feature?
+4. **Outputs**: What does the system produce or change?
+5. **Constraints**: Any hard technical constraints? (performance, compatibility, security)
+6. **Acceptance criteria**: How will you know it's done? (be specific and measurable)
+
+### Step 2: Generate Spec File
+
+Create `docs/specs/<slug>.md` with this structure:
+
+```markdown
+# Spec: <Feature Title>
+_Created: <date> | Status: draft_
+
+## Problem Statement
+<1-2 sentences: what problem, who has it>
+
+## Goal
+<What success looks like — measurable if possible>
+
+## Scope
+### In scope
+- <item>
+
+### Out of scope
+- <item>
+
+## Functional Requirements
+### FR-1: <requirement title>
+<Description>
+**Acceptance**: <testable criterion>
+
+## Non-Functional Requirements
+- **Performance**: <requirement or "none">
+- **Security**: <requirement or "none">
+- **Scalability**: <requirement or "none">
+
+## Technical Approach
+<High-level implementation strategy — 2-5 sentences>
+
+## Open Questions
+- [ ] <unresolved question>
+
+## Implementation Plan
+_To be filled by /implement-spec_
+```
+
+### Step 3: Create GitHub Issue
+
+```bash
+gh issue create \
+  --title "feat: <feature-title>" \
+  --body "Implements spec: docs/specs/<slug>.md" \
+  --label "enhancement"
+```
+
+### Step 4: Update CURRENT_TASK.md
+
+Set the task title, GitHub issue number, and done conditions from the spec's acceptance criteria.

--- a/claudex/templates/project/commands/orchestrate.md
+++ b/claudex/templates/project/commands/orchestrate.md
@@ -1,0 +1,67 @@
+# /orchestrate — Route Any Task to the Right Specialist
+
+Analyze a task and automatically route it to the correct implementer agent.
+No manual agent selection required.
+
+## Usage
+```
+/orchestrate <task-description>
+```
+Examples:
+- `/orchestrate "add a POST /users endpoint with email validation"`
+- `/orchestrate "fix the slow query on the orders table"`
+- `/orchestrate "write unit tests for the payment service"`
+
+## Process
+
+### Step 1: Classify
+
+Read the task description. Determine:
+- **Primary type**: build / fix / refactor / test / docs / research / ops
+- **Domain**: api / database / ui / infrastructure / security / data / docs
+- **Scope**: single-agent or multi-agent?
+
+### Step 2: Route
+
+**Single-agent tasks** (most tasks):
+- Use `/expert-backend` for: API, database, business logic, worker tasks
+- Use `/expert-frontend` for: UI components, styling, client-side state
+- Use `/expert-devops` for: CI/CD, Docker, deployment, monitoring
+- Use `/expert-qa` for: tests, coverage, test strategy
+- Use `/expert-architect` for: system design, architecture decisions
+
+**Multi-agent tasks** (2+ distinct concerns):
+- Use `/implement-spec` workflow (generates full agent plan)
+- Threshold: route to implement-spec when task touches 3+ files OR 2+ layers
+
+### Step 3: Generate Context
+
+Before handing off to the specialist:
+1. Generate `/context-handoff orchestrator <target-agent> "<task>"`
+2. Include the handoff document as context for the specialist
+
+### Step 4: Execute
+
+Present the specialist with:
+1. The context handoff document
+2. The task instructions
+
+### Step 5: Verify
+
+After the specialist returns:
+- Check if the done conditions are met
+- If not: clarify and re-delegate
+- If yes: confirm completion and update TASK_PROGRESS.md
+
+## Quick-Route Table
+
+| Task contains | Route to |
+|---------------|----------|
+| "endpoint", "API", "route", "REST" | expert-backend |
+| "database", "schema", "migration", "query" | expert-backend |
+| "component", "page", "UI", "style", "CSS" | expert-frontend |
+| "test", "coverage", "spec", "mock" | expert-qa |
+| "deploy", "CI", "Docker", "pipeline", "infra" | expert-devops |
+| "design", "architecture", "refactor entire" | expert-architect |
+| "document", "README", "ADR" | docs-engineer via expert-backend |
+| multiple of the above | implement-spec |

--- a/claudex/templates/project/session/CONTEXT_SUMMARY.md
+++ b/claudex/templates/project/session/CONTEXT_SUMMARY.md
@@ -1,0 +1,27 @@
+# Context Summary
+
+## Active Task
+<!-- One-line summary of what's in progress -->
+
+## Key Decisions
+<!-- Architecture and approach decisions made this session -->
+- <!-- Decision 1 -->
+
+## Files Modified
+<!-- Track touched files to avoid conflicts -->
+- <!-- file path -->
+
+## Open Questions
+<!-- Unresolved ambiguities or blockers -->
+- <!-- Question 1 -->
+
+## Re-injection Prompt
+<!--
+Paste this block into a new session to restore context:
+
+I was working on: [task title]
+Branch: [branch name]
+Last completed: [last step from TASK_PROGRESS.md]
+Next action: [first item from Next Actions]
+Key files: [list from Files Modified]
+-->

--- a/claudex/templates/project/session/CURRENT_TASK.md
+++ b/claudex/templates/project/session/CURRENT_TASK.md
@@ -1,0 +1,20 @@
+# Current Task
+
+## Task
+<!-- Brief task title -->
+
+## GitHub Issue
+<!-- Link or number, e.g. BinxAI/claudex #42 -->
+
+## Goal
+<!-- What success looks like -->
+
+## Done Conditions
+- [ ] <!-- Acceptance criterion 1 -->
+- [ ] <!-- Acceptance criterion 2 -->
+
+## Notes
+<!-- Constraints, links, context -->
+
+---
+_Created: <!-- date --> | Updated: <!-- date -->_

--- a/claudex/templates/project/session/TASK_PROGRESS.md
+++ b/claudex/templates/project/session/TASK_PROGRESS.md
@@ -1,0 +1,24 @@
+# Task Progress
+
+## Phase: Planning
+
+---
+
+## Completed Steps
+
+<!-- Add steps as they complete:
+- [x] Step description (YYYY-MM-DD)
+-->
+
+---
+
+## Next Actions
+
+<!-- Ordered list of immediate next steps -->
+1. <!-- First action -->
+
+---
+
+## Blockers
+
+None.

--- a/claudex/templates/project/session/VALIDATION_STATE.md
+++ b/claudex/templates/project/session/VALIDATION_STATE.md
@@ -1,0 +1,22 @@
+# Validation State
+
+## Gate Status
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| 1: Init | ⬜ pending | Session + GH issue required |
+| 2: Architecture | ⬜ pending | Layer violations check |
+| 3: Patterns | ⬜ pending | Code pattern compliance |
+| 4: Quality | ⬜ pending | Size limits + lint/format |
+| 5: Testing | ⬜ pending | Tests exist and pass |
+| 6: Consistency | ⬜ pending | Cross-layer field mapping |
+| 7: Audit | ⬜ pending | Final code review |
+| 8: Commit | ⬜ pending | GH# ref + policy check |
+
+## Legend
+- ✅ passed  ❌ failed  ⚠️ warning  ⬜ pending
+
+---
+
+## Notes
+<!-- Record validation findings here -->

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,7 +177,7 @@ class TestUpdateCommand:
                 "session/BACKGROUND_QUEUE.md",
                 "session/PARALLEL_SESSIONS.md",
             }
-            copy_tree(templates_dir, claude_dir, preserve_on_update=preserve_patterns)
+            copy_tree(templates_dir, claude_dir, update_mode=True, preserve_on_update=preserve_patterns)
 
             # Check session file was preserved
             if session_file.exists():


### PR DESCRIPTION
## Summary

- **Session file templates** (#6): CURRENT_TASK.md, TASK_PROGRESS.md, VALIDATION_STATE.md, CONTEXT_SUMMARY.md — distributed to users on `claudex init`
- **Agents layer** (#7, #8, #9): `orchestrator.md` (meta-routing agent), `implementers.yml` (8 roles), `verifiers.yml` (4 roles)
- **Spec lifecycle + orchestration commands** (#10, #11): `/new-spec`, `/create-spec`, `/implement-spec` (5-phase), `/context-handoff`, `/orchestrate`
- **CLI `--multi-agent` flag** (#12): `claudex init --multi-agent` installs agents/ dir and spec commands
- **Bug fix**: `copier.py` preserve_on_update logic fixed to use root-relative paths across recursive calls
- **Bug fix**: `.gitignore` negation exceptions for session template files

## Test plan

- [x] 74/76 tests pass (2 pre-existing failures: missing `empty_project` fixture on Windows)
- [x] `test_update_preserves_session_files` now correctly tests update_mode=True
- [x] `ruff check` passes on all modified files
- [x] `claudex validate` will detect missing `token-budget.py` (from PR #13, merge that first)

## Merge order

Merge PR #13 (hook upgrades) before this PR to avoid validator mismatch.

Closes #6, #7, #8, #9, #10, #11, #12