### PR TITLE
feat(compiler): compile YAML role registries into individual agent files

### DIFF
--- a/claudex/compiler.py
+++ b/claudex/compiler.py
@@ -1,0 +1,174 @@
+"""Agent file compiler — renders YAML role registries into individual .md agent files.
+
+Reads implementers.yml and verifiers.yml from the ClaudeX agent registry and writes
+one .md file per role into the target agents directory. Called by cli.py during
+`claudex init --multi-agent`.
+"""
+
+from pathlib import Path
+
+import yaml
+
+_IMPLEMENTER_TEMPLATE = """\
+# {name}
+
+You are the **{name}** — a specialist implementer for this project.
+
+## Your Responsibility
+
+{description}
+
+## Focus Areas
+
+{focus_list}
+
+## Files You Own
+
+{files_owned_list}
+
+## Files You Must NOT Touch
+
+{must_not_touch_list}
+
+## Working Style
+
+- Follow the project's CLAUDE.md architecture rules at all times
+- Write tests for all code you implement (see TESTING_GUIDELINES.md)
+- Keep files \u2264300 lines (hard limit: 500 lines)
+- Run lint and format before signaling completion
+- Update `.claude/session/TASK_PROGRESS.md` when done
+- Use `/context-handoff` to hand back to the orchestrator when complete
+
+## Done Signal
+
+When your work is complete, output:
+
+```
+DONE: [brief summary of what was implemented]
+Files changed: [list]
+Tests: [pass/fail count]
+```
+"""
+
+_VERIFIER_TEMPLATE = """\
+# {name}
+
+You are the **{name}** — you run AFTER implementers complete to validate the work.
+
+## Your Responsibility
+
+{description}
+
+## What to Check
+
+{checks_list}
+
+## Output
+
+Write your findings to `{output}`.
+
+Use this format:
+
+```markdown
+# {name} Report
+_Checked: [date]_
+
+## Summary
+[PASS / FAIL with one-line explanation]
+
+## Issues Found
+
+### Critical
+- [file:line] [description]
+
+### Warnings
+- [file:line] [description]
+
+## Verdict
+[MERGE_READY / NEEDS_FIXES / BLOCK_MERGE]
+```
+
+## Blocking Criteria
+
+**Blocks merge on**: {blocks_merge_on} issues.
+
+If you find blocking issues, recommend routing back to the relevant implementer.
+"""
+
+
+def compile_implementer_agents(agents_yml: Path, dest_dir: Path) -> list[str]:
+    """Read implementers.yml and write one .md file per role.
+
+    Returns list of created filenames (e.g. ['api-engineer.md', ...]).
+    """
+    if not agents_yml.exists():
+        return []
+
+    data = yaml.safe_load(agents_yml.read_text(encoding="utf-8"))
+    created: list[str] = []
+
+    for role in data.get("roles", []):
+        role_id = role["id"]
+        name = role.get("name", role_id)
+        description = role.get("description", "")
+        focus = role.get("focus", [])
+        files_owned = role.get("files_owned", [])
+        must_not_touch = role.get("must_not_touch", [])
+
+        focus_list = "\n".join(f"- {item}" for item in focus) if focus else "- See CLAUDE.md"
+        files_owned_list = (
+            "\n".join(f"- `{p}`" for p in files_owned) if files_owned else "- Project-dependent"
+        )
+        must_not_touch_list = (
+            "\n".join(f"- `{p}`" for p in must_not_touch) if must_not_touch else "- None specified"
+        )
+
+        content = _IMPLEMENTER_TEMPLATE.format(
+            name=name,
+            description=description,
+            focus_list=focus_list,
+            files_owned_list=files_owned_list,
+            must_not_touch_list=must_not_touch_list,
+        )
+
+        out_path = dest_dir / f"{role_id}.md"
+        out_path.write_text(content, encoding="utf-8")
+        created.append(f"{role_id}.md")
+
+    return created
+
+
+def compile_verifier_agents(verifiers_yml: Path, dest_dir: Path) -> list[str]:
+    """Read verifiers.yml and write one .md file per role.
+
+    Returns list of created filenames (e.g. ['architecture-verifier.md', ...]).
+    """
+    if not verifiers_yml.exists():
+        return []
+
+    data = yaml.safe_load(verifiers_yml.read_text(encoding="utf-8"))
+    created: list[str] = []
+
+    for role in data.get("roles", []):
+        role_id = role["id"]
+        name = role.get("name", role_id)
+        description = role.get("description", "")
+        checks = role.get("checks", [])
+        output = role.get("output", "verification/report.md")
+        blocks_merge_on = role.get("blocks_merge_on", "critical")
+
+        checks_list = "\n".join(f"- {c}" for c in checks) if checks else "- See project guidelines"
+
+        content = _VERIFIER_TEMPLATE.format(
+            name=name,
+            description=description,
+            checks_list=checks_list,
+            output=output,
+            blocks_merge_on=blocks_merge_on,
+        )
+
+        out_path = dest_dir / f"{role_id}.md"
+        out_path.write_text(content, encoding="utf-8")
+        created.append(f"{role_id}.md")
+
+    return created

--- a/claudex/copier.py
+++ b/claudex/copier.py
@@ -20,6 +20,7 @@ PRESERVE_ON_UPDATE = {
     "session/CONTEXT_SUMMARY.md",
     "session/BACKGROUND_QUEUE.md",
     "session/PARALLEL_SESSIONS.md",
+    "session/TOKEN_LOG.md",
     "feedback/VIOLATIONS_LOG.md",
     "feedback/LESSONS_LEARNED_INDEX.md",
     "feedback/PATTERN_CORRECTIONS.md",

--- a/claudex/templates/project/session/TOKEN_LOG.md
+++ b/claudex/templates/project/session/TOKEN_LOG.md
@@ -1,0 +1,36 @@
+# Token Budget Log
+
+Tracks cumulative token spend per session. Written by the `token-budget.py` PreToolUse hook.
+
+**Format**: one row per tool call that crosses a threshold checkpoint.
+
+---
+
+## Log
+
+| Timestamp (UTC) | Tool | Estimated Tokens | Session Total | % of Budget |
+|-----------------|------|-----------------|---------------|-------------|
+| _auto-populated by token-budget.py_ | | | | |
+
+---
+
+## Budget Configuration
+
+Edit `.claude/hooks/token-budget.py` to change thresholds:
+
+```python
+WARN_THRESHOLD = 0.80   # Warn at 80% of budget
+BLOCK_THRESHOLD = 1.00  # Block at 100% of budget
+SESSION_BUDGET = 200000 # Tokens per session (adjust to your plan)
+```
+
+---
+
+## Reading This File
+
+- **Session Total**: cumulative tokens since the current session started
+- **% of Budget**: total / SESSION_BUDGET * 100
+- When % reaches WARN_THRESHOLD: hook prints a warning in tool output
+- When % reaches BLOCK_THRESHOLD: hook blocks the tool call and outputs a stop message
+
+Reset by deleting the log rows below the header (the hook appends new rows on each run).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ description = "Set up Claude Code for any project in one command"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "pyyaml>=6.0",
+]
 keywords = [
     "claude",
     "claude-code",

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,0 +1,199 @@
+"""Tests for claudex.compiler — YAML registry → individual agent .md file compilation."""
+
+import pytest
+import yaml
+
+from claudex.compiler import compile_implementer_agents, compile_verifier_agents
+
+
+@pytest.fixture()
+def implementers_yml(tmp_path):
+    """Minimal implementers.yml with 2 roles."""
+    data = {
+        "version": "1.0",
+        "roles": [
+            {
+                "id": "api-engineer",
+                "name": "API Engineer",
+                "description": "Builds REST endpoints.",
+                "focus": ["REST design", "Pydantic validation"],
+                "files_owned": ["src/api/**"],
+                "must_not_touch": ["src/core/**"],
+            },
+            {
+                "id": "database-engineer",
+                "name": "Database Engineer",
+                "description": "Manages ORM and migrations.",
+                "focus": ["SQLAlchemy models", "Alembic migrations"],
+                "files_owned": ["src/db/**", "alembic/**"],
+                "must_not_touch": ["src/api/**"],
+            },
+        ],
+    }
+    yml_file = tmp_path / "implementers.yml"
+    yml_file.write_text(yaml.dump(data), encoding="utf-8")
+    return yml_file
+
+
+@pytest.fixture()
+def verifiers_yml(tmp_path):
+    """Minimal verifiers.yml with 2 roles."""
+    data = {
+        "version": "1.0",
+        "roles": [
+            {
+                "id": "architecture-verifier",
+                "name": "Architecture Verifier",
+                "description": "Checks layer boundaries.",
+                "checks": ["Layer violations", "Circular imports"],
+                "output": "verification/architecture-report.md",
+                "blocks_merge_on": "critical",
+            },
+            {
+                "id": "security-verifier",
+                "name": "Security Verifier",
+                "description": "OWASP Top 10 scan.",
+                "checks": ["SQL injection", "Hardcoded secrets"],
+                "output": "verification/security-report.md",
+                "blocks_merge_on": "any",
+            },
+        ],
+    }
+    yml_file = tmp_path / "verifiers.yml"
+    yml_file.write_text(yaml.dump(data), encoding="utf-8")
+    return yml_file
+
+
+class TestCompileImplementerAgents:
+    def test_creates_one_file_per_role(self, implementers_yml, tmp_path):
+        created = compile_implementer_agents(implementers_yml, tmp_path)
+        assert created == ["api-engineer.md", "database-engineer.md"]
+        assert (tmp_path / "api-engineer.md").exists()
+        assert (tmp_path / "database-engineer.md").exists()
+
+    def test_file_contains_role_name(self, implementers_yml, tmp_path):
+        compile_implementer_agents(implementers_yml, tmp_path)
+        content = (tmp_path / "api-engineer.md").read_text(encoding="utf-8")
+        assert "API Engineer" in content
+
+    def test_file_contains_description(self, implementers_yml, tmp_path):
+        compile_implementer_agents(implementers_yml, tmp_path)
+        content = (tmp_path / "api-engineer.md").read_text(encoding="utf-8")
+        assert "Builds REST endpoints." in content
+
+    def test_file_contains_focus_items(self, implementers_yml, tmp_path):
+        compile_implementer_agents(implementers_yml, tmp_path)
+        content = (tmp_path / "api-engineer.md").read_text(encoding="utf-8")
+        assert "REST design" in content
+        assert "Pydantic validation" in content
+
+    def test_file_contains_files_owned(self, implementers_yml, tmp_path):
+        compile_implementer_agents(implementers_yml, tmp_path)
+        content = (tmp_path / "api-engineer.md").read_text(encoding="utf-8")
+        assert "src/api/**" in content
+
+    def test_file_contains_must_not_touch(self, implementers_yml, tmp_path):
+        compile_implementer_agents(implementers_yml, tmp_path)
+        content = (tmp_path / "api-engineer.md").read_text(encoding="utf-8")
+        assert "src/core/**" in content
+
+    def test_returns_empty_list_when_file_missing(self, tmp_path):
+        result = compile_implementer_agents(tmp_path / "missing.yml", tmp_path)
+        assert result == []
+
+    def test_handles_empty_optional_fields(self, tmp_path):
+        """Roles with no focus/files_owned/must_not_touch should not crash."""
+        data = {
+            "version": "1.0",
+            "roles": [{"id": "minimal-agent", "name": "Minimal", "description": "Bare minimum."}],
+        }
+        yml = tmp_path / "minimal.yml"
+        yml.write_text(yaml.dump(data), encoding="utf-8")
+        created = compile_implementer_agents(yml, tmp_path)
+        assert created == ["minimal-agent.md"]
+        content = (tmp_path / "minimal-agent.md").read_text(encoding="utf-8")
+        assert "Minimal" in content
+
+
+class TestCompileVerifierAgents:
+    def test_creates_one_file_per_role(self, verifiers_yml, tmp_path):
+        created = compile_verifier_agents(verifiers_yml, tmp_path)
+        assert created == ["architecture-verifier.md", "security-verifier.md"]
+        assert (tmp_path / "architecture-verifier.md").exists()
+        assert (tmp_path / "security-verifier.md").exists()
+
+    def test_file_contains_verifier_name(self, verifiers_yml, tmp_path):
+        compile_verifier_agents(verifiers_yml, tmp_path)
+        content = (tmp_path / "architecture-verifier.md").read_text(encoding="utf-8")
+        assert "Architecture Verifier" in content
+
+    def test_file_contains_checks(self, verifiers_yml, tmp_path):
+        compile_verifier_agents(verifiers_yml, tmp_path)
+        content = (tmp_path / "architecture-verifier.md").read_text(encoding="utf-8")
+        assert "Layer violations" in content
+        assert "Circular imports" in content
+
+    def test_file_contains_output_path(self, verifiers_yml, tmp_path):
+        compile_verifier_agents(verifiers_yml, tmp_path)
+        content = (tmp_path / "architecture-verifier.md").read_text(encoding="utf-8")
+        assert "verification/architecture-report.md" in content
+
+    def test_file_contains_blocks_merge_on(self, verifiers_yml, tmp_path):
+        compile_verifier_agents(verifiers_yml, tmp_path)
+        content = (tmp_path / "security-verifier.md").read_text(encoding="utf-8")
+        assert "any" in content
+
+    def test_returns_empty_list_when_file_missing(self, tmp_path):
+        result = compile_verifier_agents(tmp_path / "missing.yml", tmp_path)
+        assert result == []
+
+
+class TestCompilerWithRealRegistries:
+    """Integration tests using the actual YAML registries from the package templates."""
+
+    def test_compiles_all_eight_implementers(self, tmp_path):
+        from claudex.copier import PROJECT_TEMPLATE
+
+        agents_yml = PROJECT_TEMPLATE / "agents" / "implementers.yml"
+        created = compile_implementer_agents(agents_yml, tmp_path)
+        expected_ids = [
+            "api-engineer",
+            "database-engineer",
+            "ui-designer",
+            "testing-engineer",
+            "devops-engineer",
+            "security-engineer",
+            "data-engineer",
+            "docs-engineer",
+        ]
+        assert len(created) == 8
+        for role_id in expected_ids:
+            assert f"{role_id}.md" in created
+            assert (tmp_path / f"{role_id}.md").exists()
+
+    def test_compiles_all_four_verifiers(self, tmp_path):
+        from claudex.copier import PROJECT_TEMPLATE
+
+        verifiers_yml = PROJECT_TEMPLATE / "agents" / "verifiers.yml"
+        created = compile_verifier_agents(verifiers_yml, tmp_path)
+        expected_ids = [
+            "architecture-verifier",
+            "security-verifier",
+            "quality-verifier",
+            "test-verifier",
+        ]
+        assert len(created) == 4
+        for role_id in expected_ids:
+            assert f"{role_id}.md" in created
+            assert (tmp_path / f"{role_id}.md").exists()
+
+    def test_all_agent_files_are_valid_markdown(self, tmp_path):
+        from claudex.copier import PROJECT_TEMPLATE
+
+        compile_implementer_agents(PROJECT_TEMPLATE / "agents" / "implementers.yml", tmp_path)
+        compile_verifier_agents(PROJECT_TEMPLATE / "agents" / "verifiers.yml", tmp_path)
+
+        for md_file in tmp_path.glob("*.md"):
+            content = md_file.read_text(encoding="utf-8")
+            assert content.startswith("#"), f"{md_file.name} must start with a heading"
+            assert len(content) > 100, f"{md_file.name} is suspiciously short"


### PR DESCRIPTION
## What

Closes #20 — agent file compilation
Closes #21 — TOKEN_LOG.md session template
Refs #19 (Phase 2 Epic)

## Problem

`claudex init --multi-agent` was copying `implementers.yml` + `verifiers.yml` into `.claude/agents/` but never generating individual agent files. Without `api-engineer.md`, `database-engineer.md`, etc., the orchestrator had nothing to route to.

## Solution

New `claudex/compiler.py`:
- `compile_implementer_agents(yml, dest)` — reads implementers.yml → writes 8 individual agent .md files
- `compile_verifier_agents(yml, dest)` — reads verifiers.yml → writes 4 verifier .md files

Updated `cli.py _init_multi_agent_files()` to call the compiler after YAML copy.

Added `pyyaml>=6.0` as package dependency (was already installed in most envs).

## After This PR

`claudex init --multi-agent` produces:
```
.claude/agents/
  orchestrator.md
  implementers.yml
  verifiers.yml
  api-engineer.md         ← NEW
  database-engineer.md    ← NEW
  ui-designer.md          ← NEW
  testing-engineer.md     ← NEW
  devops-engineer.md      ← NEW
  security-engineer.md    ← NEW
  data-engineer.md        ← NEW
  docs-engineer.md        ← NEW
  architecture-verifier.md ← NEW
  security-verifier.md    ← NEW
  quality-verifier.md     ← NEW
  test-verifier.md        ← NEW
```

## Test Plan

- [x] 17 new tests in `tests/test_compiler.py`
- [x] Integration tests using real YAML registries (all 8 implementers + all 4 verifiers)
- [x] All 93 tests pass
- [x] ruff check + format clean